### PR TITLE
chore(package): specify min pnpm version in engines field

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.0",
   "type": "module",
   "engines": {
-    "node": ">= 20.15"
+    "node": ">= 20.15",
+    "pnpm": ">=10.3.0"
   },
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Added a minimum pnpm version requirement (>=10.3.0) to the package.json engines field to ensure consistency across development and CI/CD environments.