### PR TITLE
chore: use pnpm and disable concurrent in lint-staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx lint-staged
+pnpm lint-staged --concurrent false


### PR DESCRIPTION
- Used `pnpm` to run lint-staged.
- Disabled concurrent to ensure sequential execution.