### PR TITLE
chore: use pnpm to run commitlint

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-npx --no -- commitlint --edit $1
+pnpm exec commitlint --edit $1


### PR DESCRIPTION
- Used `pnpm` instead of `npx` to run commitlint.